### PR TITLE
 Corrected entity relationships in model classes

### DIFF
--- a/src/main/java/com/springboot/insurance_management/controller/PolicyController.java
+++ b/src/main/java/com/springboot/insurance_management/controller/PolicyController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Set;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -45,7 +46,7 @@ public class PolicyController {
     }
       //http://localhost:8080/api/v1/policy/1/customers
     @GetMapping("/policy/{policyId}/customers")
-    public ResponseEntity<List<Customer>>getCustomersByPolicyId(@PathVariable("policyId")int policyId){
+    public ResponseEntity<Set<Customer>>getCustomersByPolicyId(@PathVariable("policyId")int policyId){
         return policyService.getCustomersByPolicyId(policyId);
 
     }

--- a/src/main/java/com/springboot/insurance_management/model/Claim.java
+++ b/src/main/java/com/springboot/insurance_management/model/Claim.java
@@ -27,9 +27,13 @@ public class Claim {
     private String claimStatus;
 
     private LocalDate claimDate;
+
+    //many to one mapping with customer
     @ManyToOne
     @JoinColumn(name="customer_id", nullable = false)
-    private Customer customers;
+    private Customer customer;
+
+    //many-to-one mapping with policy
     @ManyToOne
     @JoinColumn(name="policy_id", nullable = false)
     private Policy policy;

--- a/src/main/java/com/springboot/insurance_management/model/Customer.java
+++ b/src/main/java/com/springboot/insurance_management/model/Customer.java
@@ -14,7 +14,7 @@ import java.util.Set;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name="customers")
+@Table(name="customer")
 public class Customer {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,12 +32,18 @@ public class Customer {
     private int phoneNumber;
     @Column(nullable = false, name="date_of_birth")
     private LocalDate dateOfBirth;
+
+    //many-to-many mapping with policy
     @ManyToMany(cascade=CascadeType.ALL)
-    @JoinTable( joinColumns=@JoinColumn(name="customer_id"),
+    @JoinTable(
+            name="customer_policy",
+            joinColumns=@JoinColumn(name="customer_id"),
             inverseJoinColumns =@JoinColumn(name="policy_id")
 
     )
     private Set<Policy> policies;
-    @OneToMany(mappedBy = "customers")
+
+    //one-to-many with claims
+    @OneToMany(mappedBy = "customer" ,cascade=CascadeType.ALL, orphanRemoval = true)
     private List<Claim>claims;
 }

--- a/src/main/java/com/springboot/insurance_management/model/Policy.java
+++ b/src/main/java/com/springboot/insurance_management/model/Policy.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDate;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -33,9 +34,13 @@ public class Policy {
     private LocalDate startDate;
 
     private LocalDate endDate;
+
+    //many-to-many mapping with customer
     @ManyToMany(mappedBy = "policies")
-    private List<Customer> customers;
-    @OneToMany(mappedBy="policy", cascade = CascadeType.ALL)
+    private Set<Customer> customers=new HashSet<>();
+
+    //one-to-many mapping with Claims
+    @OneToMany(mappedBy="policy", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<Claim>claims;
 
 }

--- a/src/main/java/com/springboot/insurance_management/service/PolicyService.java
+++ b/src/main/java/com/springboot/insurance_management/service/PolicyService.java
@@ -12,9 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.PathVariable;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @Service
 public class PolicyService {
@@ -41,11 +39,11 @@ public class PolicyService {
         return new ResponseEntity<>("Policy deleted successfully", HttpStatus.OK);
     }
 
-    public ResponseEntity<List<Customer>> getCustomersByPolicyId(int policyId) {
+    public ResponseEntity<Set<Customer>> getCustomersByPolicyId(int policyId) {
         Policy policy = policyRepository.findById(policyId)
                 .orElseThrow(() -> new ResourceNotFoundException("Policy", "policyId", String.valueOf(policyId)));
 
-        List<Customer> customers = new ArrayList<>(policy.getCustomers());
+        Set<Customer> customers = new HashSet<>(policy.getCustomers());
         return new ResponseEntity<>(customers, HttpStatus.OK);
     }
 


### PR DESCRIPTION
Fixed @ManyToMany mapping between Customer and Policy to properly maintain bidirectional relationships.
Updated @OneToMany & @ManyToOne mappings for Claim to correctly reference Customer and Policy.
Ensured Set<> instead of List<> for better consistency in Many-to-Many relationships.
Defined explicit join table (customer_policy) to correctly link customers and policies.
Fixed incorrect mappedBy values in Claim, Customer, and Policy entities.
Cleaned up redundant annotations and ensured proper cascading behavior.

Impact:
Resolves issue of empty responses when querying customers by policy ID.
Ensures that the join table (customer_policy) gets populated correctly.
Prevents orphaned claims and improves data integrity.